### PR TITLE
bump bounds for QuickCheck

### DIFF
--- a/xz/xz.cabal
+++ b/xz/xz.cabal
@@ -69,7 +69,7 @@ test-suite lzma-tests
                      , bytestring
   -- additional dependencies that require version bounds
   build-depends:       HUnit                      >= 1.2      && <1.7
-                     , QuickCheck                 >= 2.8      && <2.15
+                     , QuickCheck                 >= 2.8      && <2.16
                      , tasty                      >= 0.10     && <1.6
                      , tasty-hunit                >= 0.9      && <0.11
                      , tasty-quickcheck           >= 0.8.3.2  && <0.12


### PR DESCRIPTION
xz builds with QC 2.15 (ghc v9.10.3, nixOS / wsl)